### PR TITLE
Make sure we don't get a doctrine error message.

### DIFF
--- a/Resources/views/Security/login.html.twig
+++ b/Resources/views/Security/login.html.twig
@@ -13,7 +13,7 @@
 
         {% if error %}
             <div class="alert alert-info">
-                {{ error|trans }}
+                {{ error.messageKey|trans(error.messageData, 'security') }}
             </div>
         {% endif %}
 


### PR DESCRIPTION
The old exception message gave us a lot of info about our application.
This could help a user find out we're running Symfony and find possible exploits.

This commit will hide the message behind a translated version of the message of the exception.

See:
- https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Changelog.md
- https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Resources/views/Security/login.html.twig#L7
